### PR TITLE
Fix initial selection in Node_App CSV dropdown

### DIFF
--- a/Node_App/main.html
+++ b/Node_App/main.html
@@ -400,6 +400,8 @@
         .text(d => d);
       // Load the default CSV file (first in the list)
       if(csvFiles.length > 0){
+        // Ensure the selector reflects the initially loaded file
+        csvSelector.property("value", csvFiles[0]);
         loadCSVData(csvFiles[0]);
       } else {
         console.error("No CSV files found in the data folder.");


### PR DESCRIPTION
## Summary
- Ensure CSV selector defaults to the first available file so the dropdown reflects the loaded data

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_b_6894dad944088333a83221c69794f95b