### PR TITLE
Allow collapsing nodes with hidden neighbors

### DIFF
--- a/Node_App/main.html
+++ b/Node_App/main.html
@@ -173,6 +173,8 @@
       .attr("width", width)
       .attr("height", height);
 
+    const COLLAPSED_DISTANCE = 20;
+
     // Group for all visualization elements (for zooming/panning)
     const svgGroup = svg.append("g").attr("class", "everything");
 
@@ -247,7 +249,7 @@
 
       // Create force simulation
       const simulation = d3.forceSimulation(nodes)
-        .force("link", d3.forceLink(links).id(d => d.id).distance(d => d.collapsed ? 1 : d.distance))
+        .force("link", d3.forceLink(links).id(d => d.id).distance(l => l.collapsed ? COLLAPSED_DISTANCE : l.distance))
         .force("charge", d3.forceManyBody().strength(-200))
         .force("center", d3.forceCenter(width / 2, height / 2));
 
@@ -293,22 +295,28 @@
           links.forEach(l => {
             if (l.source === d || l.target === d) {
               const neighbor = l.source === d ? l.target : l.source;
-              const neighborLinks = links.filter(ol => ol.source === neighbor || ol.target === neighbor);
-              if (neighborLinks.length === 1) {
-                if (d.collapsed) {
+              const neighborLinks = links.filter(
+                ol => (ol.source === neighbor || ol.target === neighbor) && !ol.collapsed
+              );
+              if (d.collapsed) {
+                if (neighborLinks.length === 1) {
                   l.collapsed = true;
                   neighbor.hidden = true;
-                } else {
-                  l.collapsed = false;
-                  neighbor.hidden = false;
                 }
+              } else if (l.collapsed) {
+                l.collapsed = false;
+                neighbor.hidden = false;
               }
             }
           });
           node.style("display", n => n.hidden ? "none" : null);
           labels.style("display", n => n.hidden ? "none" : null);
           connectorLabels.style("display", l => l.collapsed ? "none" : null);
-          simulation.force("link").distance(l => l.collapsed ? 1 : l.distance);
+          simulation.force("link").distance(l =>
+            l.collapsed || l.source.collapsed || l.target.collapsed
+              ? COLLAPSED_DISTANCE
+              : l.distance
+          );
           simulation.alpha(1).restart();
         });
 


### PR DESCRIPTION
## Summary
- Treat collapsed links as removed when checking for leaf nodes
- Restore nodes that were previously collapsed when expanding a parent
- Shorten link distance for collapsed nodes to keep collapsed clusters tight

## Testing
- `npm test --prefix src`


------
https://chatgpt.com/codex/tasks/task_b_6894e2dbb54c8333996802d92091d2d4